### PR TITLE
Openalea channel for binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,6 +1,7 @@
 name: phenomenal
 channels:
   - conda-forge
+  - openalea
 
 dependencies:
   - openalea.phenomenal


### PR DESCRIPTION
In fact we still need the openalea channels event without deploy ... otherwise binder can't find the package openalea.phenomenal