### PR TITLE
switch to text mode for csv input/output

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,9 @@ environment:
   CONDA_VERSION: 3
       
   matrix:
-  # Add here environement variables to control the Travis CI build
     - CONDA_PY: 37
     - CONDA_PY: 38
       CONDA_NPY: 116
-    - CONDA_PY: 39
-      CONDA_NPY: 119
 
 install:
   - git clone https://github.com/openalea/appveyor-ci.git

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,9 +3,16 @@ platform:
   - x64
 
 environment:
+  CONDA_RECIPE: conda
+  CONDA_VERSION: 3
+      
   matrix:
-    - CONDA_RECIPE: conda
-      CONDA_VERSION: 37
+  # Add here environement variables to control the Travis CI build
+    - CONDA_PY: 37
+    - CONDA_PY: 38
+      CONDA_NPY: 116
+    - CONDA_PY: 39
+      CONDA_NPY: 119
 
 install:
   - git clone https://github.com/openalea/appveyor-ci.git

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ platform:
 environment:
   matrix:
     - CONDA_RECIPE: conda
-      CONDA_VERSION: 3
+      CONDA_VERSION: 37
 
 install:
   - git clone https://github.com/openalea/appveyor-ci.git

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openalea.phenomenal
-  version: "1.7.0b0"
+  version: "1.7.1"
 
 source:
   path: ..

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ extentions = [
 
 setup(
     name="openalea.phenomenal",
-    version="1.7.0b0",
+    version="1.7.1",
     description="",
     long_description="",
 

--- a/src/openalea/phenomenal/object/voxelGrid.py
+++ b/src/openalea/phenomenal/object/voxelGrid.py
@@ -214,7 +214,7 @@ class VoxelGrid(object):
                 filename))):
             os.makedirs(os.path.dirname(filename))
 
-        f = open(filename, 'wb')
+        f = open(filename, 'w')
         for x, y, z in self.voxels_position:
             f.write("%f %f %f \n" % (x, y, z))
         f.close()
@@ -242,7 +242,7 @@ class VoxelGrid(object):
                 filename))):
             os.makedirs(os.path.dirname(filename))
 
-        with open(filename, 'wb') as f:
+        with open(filename, 'w') as f:
             c = csv.writer(f)
 
             c.writerow(['x_coord', 'y_coord', 'z_coord', 'voxel_size'])
@@ -252,7 +252,7 @@ class VoxelGrid(object):
 
     @staticmethod
     def read_from_csv(filename):
-        with open(filename, 'rb') as f:
+        with open(filename, 'r') as f:
             reader = csv.reader(f)
 
             next(reader)

--- a/src/openalea/phenomenal/object/voxelGrid.py
+++ b/src/openalea/phenomenal/object/voxelGrid.py
@@ -19,6 +19,18 @@ from .image3D import Image3D
 # ==============================================================================
 
 
+class NumpyEncoder(json.JSONEncoder):
+    """ Special json encoder for numpy types """
+    def default(self, obj):
+        if isinstance(obj, numpy.integer):
+            return int(obj)
+        elif isinstance(obj, numpy.floating):
+            return float(obj)
+        elif isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
+
 class VoxelGrid(object):
 
     def __init__(self, voxels_position, voxels_size):
@@ -195,16 +207,17 @@ class VoxelGrid(object):
 
             data = dict()
             data['voxels_size'] = self.voxels_size
-            data['voxels_position'] = list(map(tuple, self.voxels_position))
+            vp = list(map(tuple, self.voxels_position))
+            data['voxels_position'] = json.dumps(vp, cls=NumpyEncoder)
             json.dump(data, f)
 
     @staticmethod
     def read_from_json(filename):
 
-        with open(filename, 'rb') as f:
+        with open(filename, 'r') as f:
             data = json.load(f)
             voxels_size = data['voxels_size']
-            voxels_position = data['voxels_position']
+            voxels_position = json.loads(data['voxels_position'])
 
             return VoxelGrid(voxels_position, voxels_size)
 
@@ -242,7 +255,7 @@ class VoxelGrid(object):
                 filename))):
             os.makedirs(os.path.dirname(filename))
 
-        with open(filename, 'w') as f:
+        with open(filename, 'w', newline='') as f:
             c = csv.writer(f)
 
             c.writerow(['x_coord', 'y_coord', 'z_coord', 'voxel_size'])
@@ -252,7 +265,7 @@ class VoxelGrid(object):
 
     @staticmethod
     def read_from_csv(filename):
-        with open(filename, 'r') as f:
+        with open(filename, 'r', newline='') as f:
             reader = csv.reader(f)
 
             next(reader)

--- a/src/openalea/phenomenal/object/voxelSkeleton.py
+++ b/src/openalea/phenomenal/object/voxelSkeleton.py
@@ -57,16 +57,10 @@ class VoxelSkeleton(object):
             data['voxels_size'] = self.voxels_size
 
             for seg in self.segments:
-
                 dseg = dict()
-                node_sets = seg.closest_nodes
                 dseg['voxels_position'] = list(seg.voxels_position)
                 dseg['polyline'] = seg.polyline
-                dseg['closest_nodes'] = list()
-
-                for node_set in node_sets:
-                    dseg['closest_nodes'].append(list(node_set))
-
+                dseg['closest_nodes'] = [list(nodes) for nodes in seg.closest_nodes]
                 data['segments'].append(dseg)
 
             f.write(json.dumps(data).encode('utf-8'))
@@ -77,20 +71,13 @@ class VoxelSkeleton(object):
         with gzip.open(filename, 'rb') as f:
             data = json.loads(f.read().decode('utf-8'))
 
-            segs = list()
+            segs = []
 
             for dseg in data['segments']:
-
-                node_sets = list()
-                node_lists = dseg['closest_nodes']
-
-                for node_list in node_lists:
-
-                    node_sets.append(set(list(map(tuple, node_list))))
-
                 polyline = list(map(tuple, dseg['polyline']))
                 voxels_position = set(list(map(tuple, dseg['voxels_position'])))
-                segs.append(VoxelSegment(polyline, voxels_position, node_sets))
+                closest_nodes = [set(list(map(tuple, nodes))) for nodes in dseg['closest_nodes']]
+                segs.append(VoxelSegment(polyline, voxels_position, closest_nodes))
 
             sk = VoxelSkeleton(segs, data['voxels_size'])
 

--- a/test/test_object/test_VoxelGrid.py
+++ b/test/test_object/test_VoxelGrid.py
@@ -24,13 +24,14 @@ def test_read_write():
     voxels_position = numpy.array(list(numpy.ndindex((10, 15, 5)))) * 16
     src_vg = phm_obj.VoxelGrid(voxels_position, voxels_size)
 
-    filename = 'test.npz'
-    src_vg.write_to_npz(filename)
-    dist_vg = phm_obj.VoxelGrid.read_from_npz(filename)
-    os.remove(filename)
+    for ext in ('npz', 'json', 'csv'):
+        filename = 'test.' + ext
+        src_vg.write(filename)
+        dist_vg = phm_obj.VoxelGrid.read(filename)
+        os.remove(filename)
 
-    assert src_vg.voxels_size == dist_vg.voxels_size
-    assert (src_vg.voxels_position == dist_vg.voxels_position).all()
+        assert src_vg.voxels_size == dist_vg.voxels_size
+        assert (src_vg.voxels_position == dist_vg.voxels_position).all()
 
 
 if __name__ == "__main__":

--- a/test/test_object/test_voxelSkeleton.py
+++ b/test/test_object/test_voxelSkeleton.py
@@ -1,0 +1,37 @@
+# -*- python -*-
+#
+#       Copyright INRIA - CIRAD - INRA
+#
+#       Distributed under the Cecill-C License.
+#       See accompanying file LICENSE.txt or copy at
+#           http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html
+#
+#       OpenAlea WebSite : http://openalea.gforge.inria.fr
+#
+# ==============================================================================
+from __future__ import division, print_function
+
+import os
+
+import openalea.phenomenal.data as phm_data
+import openalea.phenomenal.object as phm_obj
+import openalea.phenomenal.segmentation as phm_seg
+# ==============================================================================
+
+
+def test_readwrite():
+
+    voxel_grid = phm_data.random_voxel_grid(voxels_size=32)
+    graph = phm_seg.graph_from_voxel_grid(voxel_grid)
+    src_vsk = phm_seg.skeletonize(voxel_grid, graph)
+    filename = 'test.json.gz'
+    src_vsk.write_to_json_gz(filename)
+    dst_vsk = phm_obj.VoxelSkeleton.read_from_json_gz(filename)
+    os.remove(filename)
+
+    assert src_vsk.voxels_size == dst_vsk.voxels_size
+    for src_seg, dst_seg in zip(src_vsk.segments, dst_vsk.segments):
+        assert src_seg.voxels_position == dst_seg.voxels_position
+        assert src_seg.polyline == dst_seg.polyline
+        for src_nodes, dst_nodes in zip(src_seg.closest_nodes, dst_seg.closest_nodes):
+            assert src_nodes == dst_nodes


### PR DESCRIPTION
VoxelGrid old serialisation are in text mode csv. For backward compatibility, this PR restore compatible reader / writer.
This does not impact current performance, as default new format for serialisation is npz.